### PR TITLE
WIP: use github actions for continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: push
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: php-actions/composer@v1 # or alternative dependency management
+    - uses: php-actions/phpunit@v1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,20 @@ on: push
 jobs:
   build-test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        php-versions:
+          - 7.1
+          - 7.2
+          - 7.3
+          - 7.4
     steps:
     - uses: actions/checkout@v2
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: intl #optional
+        ini-values: "post_max_size=256M" #optional
     - uses: php-actions/composer@v1 # or alternative dependency management
     - uses: php-actions/phpunit@v1
 


### PR DESCRIPTION
- run phpunit tests on ubuntu-latest
- https://github.com/marketplace/actions/phpunit-php-actions
- https://github.com/php-actions/example-phpunit
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on