### PR TITLE
run trivy security scans on release docker image/composer/yarn dependencies

### DIFF
--- a/.github/workflows/trivy-release.yml
+++ b/.github/workflows/trivy-release.yml
@@ -1,0 +1,26 @@
+name: trivy security scans (release)
+on:
+  schedule:
+    #- cron: '0 17 * * 1'
+    - cron: '40 * * * *'
+  workflow_dispatch:
+
+jobs:
+  trivy-repo:
+    runs-on: ubuntu-latest
+    name: trivy scan (release composer/yarn dependencies)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: release
+      - name: Run trivy scanner on repository
+        run: make test_trivy_repo TRIVY_EXIT_CODE=1
+  trivy-docker:
+    runs-on: ubuntu-latest
+    name: trivy scan (release docker image)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run trivy scanner on release docker image
+        run: make test_trivy_docker TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/shaarli/shaarli:release


### PR DESCRIPTION
- Related https://github.com/nodiscc/Shaarli/pull/19
- Second attempt at https://github.com/nodiscc/Shaarli/pull/18 which cause tests to fail https://github.com/nodiscc/Shaarli/actions/runs/6697163196

```
0s
Run make test_trivy_repo TRIVY_EXIT_CODE=1
  make test_trivy_repo TRIVY_EXIT_CODE=1
  shell: /usr/bin/bash -e {0}
make: *** No rule to make target 'test_trivy_repo'.  Stop.
Error: Process completed with exit code 2.
```

This will fail as long as this commit is not merged into `release` as the Makefile on the  `release` branch currently has no `test_trivy_repo` target.